### PR TITLE
Add overridable DisplayObject.drawHitMask() to use an arbitrary object for hit detection

### DIFF
--- a/src/easeljs/display/Container.js
+++ b/src/easeljs/display/Container.js
@@ -434,7 +434,7 @@ var p = Container.prototype = new DisplayObject();
 				child.getConcatenatedMatrix(mtx);
 				ctx.setTransform(mtx.a,  mtx.b, mtx.c, mtx.d, mtx.tx-x, mtx.ty-y);
 				ctx.globalAlpha = mtx.alpha;
-				child.draw(ctx);
+				child.drawHitMask(ctx);
 				if (!this._testHit(ctx)) { continue; }
 				canvas.width = 0;
 				canvas.width = 1;

--- a/src/easeljs/display/DisplayObject.js
+++ b/src/easeljs/display/DisplayObject.js
@@ -548,6 +548,10 @@ var p = DisplayObject.prototype;
 		return mtx;
 	}
 
+	p.drawHitMask = function(ctx) {
+		this.draw(ctx);
+	}
+
 	/**
 	* Tests whether the display object intersects the specified local point (ie. draws a pixel with alpha > 0 at
 	* the specified position). This ignores the alpha, shadow and compositeOperation of the display object, and all
@@ -563,7 +567,7 @@ var p = DisplayObject.prototype;
 		var canvas = DisplayObject._hitTestCanvas;
 
 		ctx.setTransform(1,  0, 0, 1, -x, -y);
-		this.draw(ctx);
+		this.drawHitMask(ctx);
 
 		var hit = this._testHit(ctx);
 


### PR DESCRIPTION
Currently, collision detection of an object with the mouse pointer is performed by drawing the object onto a temporary 1x1-pixel canvas, offset such that only the pixel under the mouse pointer on the main canvas is visible. If this pixel is not fully transparent, it is counted as a hit.

This patch lets `DisplayObject`s draw any object to the temporary canvas by overriding `drawHitMask()`; if they do not, `draw()` is called by the default implementation. This will allow for much cheaper hit detection of complex objects such as images or multi-layered graphics, since only a filled outline of the object's shape must be rendered, as well as allow objects to be "hit" in transparent areas.

However, if `cache()` is called on the object, then the custom hit masking is ignored, and the cached canvas used instead.  If you feel that this is acceptable as long as users are informed, then the pull request is ready for inclusion in the mainline.  If not, then another commit must be added to create a separate cached hit mask canvas in `cache()`, though it may have an entirely different size and position.
