### PR TITLE
Bugfix: Add missing variable definition

### DIFF
--- a/src/easeljs/display/Container.js
+++ b/src/easeljs/display/Container.js
@@ -235,6 +235,7 @@ var p = Container.prototype = new DisplayObject();
 	 * @method removeAllChildren
 	 **/
 	p.removeAllChildren = function() {
+		var kids = this.children;
 		for (var i=0,l=kids.length;i<l;i++) { kids[i].parent = null; }
 		this.children = [];
 	}


### PR DESCRIPTION
Just a missing line in `Container.removeAllChildren()`.
