### PR TITLE
The @param example for the font parameter of the constructor function of Text should be "bold 36px Arial" instead of "36px bold Arial"

### DIFF
--- a/src/easeljs/display/Text.js
+++ b/src/easeljs/display/Text.js
@@ -38,7 +38,7 @@
 * @constructor
 * @param {String} text Optional. The text to display.
 * @param {String} font Optional. The font style to use. Any valid value for the CSS font attribute is 
-* acceptable (ex. "36px bold Arial").
+* acceptable (ex. "bold 36px Arial").
 * @param {String} color Optional. The color to draw the text in. Any valid value for the CSS color attribute
 * is acceptable (ex. "#F00").
 **/


### PR DESCRIPTION
The @param example for the font parameter of the constructor function of Text should be "bold 36px Arial" instead of "36px bold Arial"
