### PR TITLE
Add getUserMatrix and setUserMatrix upon a DisplayObject.

### DIFF
--- a/src/easeljs/display/DisplayObject.js
+++ b/src/easeljs/display/DisplayObject.js
@@ -670,7 +670,7 @@ var p = DisplayObject.prototype;
 			this._userMatrix = new createjs.Matrix2D();
 		}
 
-		this._userMatrix.appendMatrix(matrix);
+		this._userMatrix.identity().appendMatrix(matrix);
 		return this;
 	}
 


### PR DESCRIPTION
Add getUserMatrix and setUserMatrix upon a DisplayObject
This change allows a client of DisplayObject to specify a user matrix
directly.  Without this change, and user has to decompose the matrix
into the separable components as used by setTransform which is tricky
and not always a correct representation of an arbitrary matrix.

These new routines allow a matrix to optionally be specified within the
DisplayObject.  Is used, this transform is applied to the matrix before
the matrix created using the setTransform based components.

I've performed white box testing on this and it is working great for my
needs.  I'm a Principal Scientist working at Adobe from Seattle.  If you
have any questions, don't hesitate to ask.

Thanks, Jim.
