### PR TITLE
Options hash for DisplayObject constructors

### DIFF
--- a/src/easeljs/display/Bitmap.js
+++ b/src/easeljs/display/Bitmap.js
@@ -39,7 +39,7 @@ this.createjs = this.createjs||{};
 * @param {Image | HTMLCanvasElement | HTMLVideoElement | String} imageOrUri The source object or URI to an image to display. This can be either an Image, Canvas, or Video object, or a string URI to an image file to load and use. If it is a URI, a new Image object will be constructed and assigned to the .image property.
 **/
 var Bitmap = function(imageOrUri) {
-  this.initialize(imageOrUri);
+  this.initialize.apply(this, arguments);
 }
 var p = Bitmap.prototype = new createjs.DisplayObject();
 
@@ -82,12 +82,16 @@ var p = Bitmap.prototype = new createjs.DisplayObject();
 	 * @protected
 	 **/
 	p.initialize = function(imageOrUri) {
-		this.DisplayObject_initialize();
-		if (typeof imageOrUri == "string") {
+		var opts = this._checkForOptsArg(arguments, ['string', Image]);
+		if (opts) { imageOrUri = null; }
+		
+		this.image = imageOrUri;
+		
+		this.DisplayObject_initialize(opts);
+		
+		if (typeof this.image == "string") {
 			this.image = new Image();
-			this.image.src = imageOrUri;
-		} else {
-			this.image = imageOrUri;
+			this.image.src = this.image;
 		}
 	}
 	

--- a/src/easeljs/display/BitmapAnimation.js
+++ b/src/easeljs/display/BitmapAnimation.js
@@ -44,7 +44,7 @@ this.createjs = this.createjs||{};
 * dimensions, and frame data. See SpriteSheet for more information.
 **/
 var BitmapAnimation = function(spriteSheet) {
-  this.initialize(spriteSheet);
+  this.initialize.apply(this, arguments);
 }
 var p = BitmapAnimation.prototype = new createjs.DisplayObject();
 
@@ -153,8 +153,12 @@ var p = BitmapAnimation.prototype = new createjs.DisplayObject();
 	 * @protected
 	*/
 	p.initialize = function(spriteSheet) {
-		this.DisplayObject_initialize();
+		var opts = this._checkForOptsArg(arguments, [createjs.SpriteSheet]);
+		if (opts) { spriteSheet = null; }
+		
 		this.spriteSheet = spriteSheet;
+		
+		this.DisplayObject_initialize(opts);
 	}
 
 	/**

--- a/src/easeljs/display/Container.js
+++ b/src/easeljs/display/Container.js
@@ -44,7 +44,7 @@ this.createjs = this.createjs||{};
 * @constructor
 **/
 var Container = function() {
-  this.initialize();
+  this.initialize.apply(this, arguments);
 }
 var p = Container.prototype = new createjs.DisplayObject();
 
@@ -73,8 +73,11 @@ var p = Container.prototype = new createjs.DisplayObject();
 	 * @protected
 	*/
 	p.initialize = function() {
-		this.DisplayObject_initialize();
+		var opts = this._checkForOptsArg(arguments, [createjs.SpriteSheet]);
+		
 		this.children = [];
+		
+		this.DisplayObject_initialize(opts);
 	}
 
 // public methods:

--- a/src/easeljs/display/DOMElement.js
+++ b/src/easeljs/display/DOMElement.js
@@ -53,7 +53,7 @@ this.createjs = this.createjs||{};
 * @param {HTMLElement} htmlElement A reference or id for the DOM element to manage.
 **/
 var DOMElement = function(htmlElement) {
-  this.initialize(htmlElement);
+  this.initialize.apply(this, arguments);
 }
 var p = DOMElement.prototype = new createjs.DisplayObject();
 
@@ -86,12 +86,19 @@ var p = DOMElement.prototype = new createjs.DisplayObject();
 	 * @protected
 	*/
 	p.initialize = function(htmlElement) {
-		if (typeof(htmlElement)=="string") { htmlElement = document.getElementById(htmlElement); }
-		this.DisplayObject_initialize();
+		var opts = this._checkForOptsArg(arguments, ["string", Node]);
+		if (opts) { htmlElement = null; }
+		
 		this.mouseEnabled = false;
 		this.htmlElement = htmlElement;
-		if (htmlElement) {
-			this._style = htmlElement.style;
+		
+		this.DisplayObject_initialize(opts);
+		
+		if (typeof(this.htmlElement) === "string") {
+			this.htmlElement = document.getElementById(this.htmlElement);
+		}
+		if (this.htmlElement) {
+			this._style = this.htmlElement.style;
 			this._style.position = "absolute";
 			this._style.transformOrigin = this._style.WebkitTransformOrigin = this._style.msTransformOrigin = this._style.MozTransformOrigin = this._style.OTransformOrigin = "0% 0%";
 		}

--- a/src/easeljs/display/MovieClip.js
+++ b/src/easeljs/display/MovieClip.js
@@ -47,7 +47,7 @@ this.createjs = this.createjs||{};
  * @param {Object} labels A hash of labels to pass to the timeline instance associated with this MovieClip.
  **/
 var MovieClip = function(mode, startPosition, loop, labels) {
-  this.initialize(mode, startPosition, loop, labels);
+  this.initialize.apply(this, arguments);
 }
 var p = MovieClip.prototype = new createjs.Container();
 
@@ -178,11 +178,19 @@ var p = MovieClip.prototype = new createjs.Container();
 	 * @protected
 	 **/
 	p.initialize = function(mode, startPosition, loop, labels) {
+	    var opts = this._checkForOptsArg(arguments, ["string", Node]);
+	    if (opts) {
+	        mode = null;
+	        startPosition = opts.startPosition;
+	        loop = opts.loop;
+	        labels = opts.labels;
+	    }
+	    
 		this.mode = mode||MovieClip.INDEPENDENT;
 		this.startPosition = startPosition || 0;
 		this.loop = loop;
 		props = {paused:true, position:startPosition, useTicks:true};
-		this.Container_initialize();
+		this.Container_initialize(opts);
 		this.timeline = new createjs.Timeline(null, labels, props);
 		this._managed = {};
 	}

--- a/src/easeljs/display/Stage.js
+++ b/src/easeljs/display/Stage.js
@@ -40,7 +40,7 @@ this.createjs = this.createjs||{};
 * @param {HTMLCanvasElement | String | Object} canvas A canvas object that the Stage will render to, or the string id of a canvas object in the current document.
 **/
 var Stage = function(canvas) {
-  this.initialize(canvas);
+  this.initialize.apply(this, arguments);
 }
 var p = Stage.prototype = new createjs.Container();
 
@@ -196,8 +196,16 @@ var p = Stage.prototype = new createjs.Container();
 	 * @protected
 	 **/
 	p.initialize = function(canvas) {
-		this.Container_initialize();
-		this.canvas = (typeof canvas == "string") ? document.getElementById(canvas) : canvas;
+		var opts = this._checkForOptsArg(arguments, ["string", Node]);
+		if (opts) { canvas = null; }
+		
+		this.canvas = this.canvas || canvas;
+		
+		this.Container_initialize(opts);
+		
+		if (typeof this.canvas == "string") {
+			this.canvas = document.getElementById(this.canvas);
+		}
 		this._pointerData = {};
 		this._enableMouseEvents(true);
 	}

--- a/src/easeljs/display/Text.js
+++ b/src/easeljs/display/Text.js
@@ -46,7 +46,7 @@ this.createjs = this.createjs||{};
 * is acceptable (ex. "#F00").
 **/
 var Text = function(text, font, color) {
-  this.initialize(text, font, color);
+  this.initialize.apply(this, arguments);
 }
 var p = Text.prototype = new createjs.DisplayObject();
 
@@ -143,10 +143,14 @@ var p = Text.prototype = new createjs.DisplayObject();
 	 * @protected
 	*/
 	p.initialize = function(text, font, color) {
-		this.DisplayObject_initialize();
+		var opts = this._checkForOptsArg(arguments, ["string"]);
+		if (opts) { text = null; }
+		
 		this.text = text;
 		this.font = font;
 		this.color = color ? color : "#000";
+		
+		this.DisplayObject_initialize(opts);
 	}
 	
 	/**


### PR DESCRIPTION
There's a feature I'd like, and am willing to implement. I'm wondering whether you would accept it.

Easel's API has you create a scene graph object, then set its properties:

```
var house = new createjs.Bitmap();
house.image = houseImage;
house.x = 800;
house.y = 768 - groundHeight - houseImage.height;
background.addChild(house);
```

Easel doesn't use the common Javascript idiom of accepting a params hash in the constructor. As scenes get complicated, that idiom would be really nice to have. More declarative & nestable code like this ends up being much more readable as scene size grows:

```
background.addChild(
    new createjs.Bitmap({
        image: houseImage,
        x: 800,
        y: 768 - groundHeight - houseImage.height
    })
);
```

No smattering of little vars, everything concise and nested readably.

Shape poses a special problem:

```
var circle = new createjs.Shape();
circle.x = 50;
circle.y = 100;
circle.graphics
    .setStrokeStyle(5, 'round')
    .beginStroke('black')
    .beginFill('red')
    .drawCircle(0, 0, r);
background.addChild(circle);
```

Properties like stroke width and color are mixed into the graphics object, which leads to little codeballs that can be nasty to decipher (and what •was• the order of those setStroke params again?!?). I propose a few special options for common stroke & fill options, plus a callback for the graphics:

```
background.addChild(
  new createjs.Shape({
      x: 50,
      y: 100,
      strokeWidth: 5,
      strokeCap: 'round',
      strokeColor: 'black',
      fillColor: 'red',
      graphics: function(g) { g.drawCircle(0, 0, r); }
  })
);
```

I've prototyped all of this in my project, and it cleans things up a lot!

Thoughts? If I can get together a tidy implementation that doesn't create a mess in all the Easel constructors, would you accept the pull request?
