### PR TITLE
Removed unnecessary parameter within Stage.js

### DIFF
--- a/src/easeljs/display/Stage.js
+++ b/src/easeljs/display/Stage.js
@@ -199,7 +199,7 @@ var p = Stage.prototype = new createjs.Container();
 		this.Container_initialize();
 		this.canvas = (typeof canvas == "string") ? document.getElementById(canvas) : canvas;
 		this._pointerData = {};
-		this._enableMouseEvents(true);
+		this._enableMouseEvents();
 	}
 
 // public methods:


### PR DESCRIPTION
removed unnecessary boolean parameter from call of this._enableMouseEvents(true) because function p._enableMouseEvents() does not have parameters
