### PR TITLE
Performance Bug Fix

### DIFF
--- a/src/easeljs/display/DOMElement.js
+++ b/src/easeljs/display/DOMElement.js
@@ -3,7 +3,7 @@
 * Visit http://createjs.com/ for documentation, updates and examples.
 *
 * Copyright (c) 2010 gskinner.com, inc.
-* 
+*
 * Permission is hereby granted, free of charge, to any person
 * obtaining a copy of this software and associated documentation
 * files (the "Software"), to deal in the Software without
@@ -12,10 +12,10 @@
 * copies of the Software, and to permit persons to whom the
 * Software is furnished to do so, subject to the following
 * conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be
 * included in all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -121,16 +121,40 @@ var p = DOMElement.prototype = new createjs.DisplayObject();
 	 * into itself).
 	 **/
 	p.draw = function(ctx, ignoreCache) {
-		// TODO: possibly save out previous matrix values, to compare against new ones (so layout doesn't need to fire if there is no change)
-		if (this.htmlElement == null) { return; }
-		var mtx = this.getConcatenatedMatrix(this._matrix);
-		
+		if (this.htmlElement === null) { return; }
+
+		var mtx = this._matrix;
 		var o = this.htmlElement;
-		o.style.opacity = ""+mtx.alpha;
-		// this relies on the _tick method because draw isn't called if a parent is not visible.
-		o.style.visibility = this.visible ? "visible" : "hidden";
-		o.style.transform = o.style.WebkitTransform = o.style.OTransform =  o.style.msTransform = ["matrix("+mtx.a,mtx.b,mtx.c,mtx.d,(mtx.tx+0.5|0),(mtx.ty+0.5|0)+")"].join(",");
-		o.style.MozTransform = ["matrix("+mtx.a,mtx.b,mtx.c,mtx.d,(mtx.tx+0.5|0)+"px",(mtx.ty+0.5|0)+"px)"].join(",");
+
+		if (!o.hasOwnProperty('_oldValues')) {
+			o._oldValues = {};
+		}
+
+		var styleText = '';
+
+		var updateStyle = function (property, value) {
+			if (!o._oldValues[property] || o._oldValues[property] !== value) {
+				styleText += property + ':' + value + ';';
+				o._oldValues[property] = value;
+			}
+		};
+
+		updateStyle('opacity', '' + mtx.alpha);
+		updateStyle('visibility', this.visible ? 'visible' : 'hidden');
+
+		var transformTxt = ["matrix("+mtx.a,mtx.b,mtx.c,mtx.d,mtx.tx,mtx.ty+")"].join(",");
+		var mozTransformTxt = ["matrix("+mtx.a,mtx.b,mtx.c,mtx.d,mtx.tx+"px",mtx.ty+"px)"].join(",");
+
+		updateStyle('transform', transformTxt);
+		updateStyle('-webkit-transform', transformTxt);
+		updateStyle('-o-transform', transformTxt);
+		updateStyle('-ms-transform', transformTxt);
+		updateStyle('-moz-transform', mozTransformTxt);
+
+		if (styleText) {
+			o.style.cssText += ';' + styleText;
+		}
+
 		return true;
 	}
 
@@ -199,7 +223,6 @@ var p = DOMElement.prototype = new createjs.DisplayObject();
 // private methods:
 	p._tick = function(data) {
 		if (this.htmlElement == null) { return; }
-		this.htmlElement.style.visibility = "hidden";
 		if (this.onTick) { this.onTick(data); }
 	}
 


### PR DESCRIPTION
This fix removes a lot of unnecessary redraws of DOM elements. This can have a significant performance impact. On one of our projects it cut CPU usage from 120% to 8%.

It simply adds a _oldValues object as a property of the DOM element and checks if the values have changed since last time - if not no redraw in needed.

Most of the additional code is just to update using the correct vendor prefixes - this can possibly be neatened.
