### PR TITLE
Ticker  combined tick event object

### DIFF
--- a/src/easeljs/utils/Ticker.js
+++ b/src/easeljs/utils/Ticker.js
@@ -431,18 +431,27 @@ var Ticker = function() {
 		Ticker._lastTime = time;
 		
 		var totalElapsed = time - Ticker._startTime;
-		var runTimeElapsed = totalElapsed - Ticker._pausedTime;
+		var tickEvent = {
+			type:'tick',
+			paused: paused,
+			delta: elapsedTime,
+			time: totalElapsed,
+			runTime: totalElapsed - Ticker._pausedTime,
+			ticks: this._ticks,
+			runTicks: this._ticks - this._pausedTicks
+		};
+
 		var pauseable = Ticker._pauseable;
 		var listeners = Ticker._listeners.slice();
 		var l = listeners ? listeners.length : 0;
 		for (var i=0; i<l; i++) {
 			var listener = listeners[i];
 			if (listener == null || (paused && pauseable[i])) { continue; }
-			if (listener.tick) { listener.tick(elapsedTime, paused, runTimeElapsed, totalElapsed); }
-			else if (listener instanceof Function) { listener(elapsedTime, paused, runTimeElapsed, totalElapsed); }
+			if (listener.tick) { listener.tick(tickEvent); }
+			else if (listener instanceof Function) { listener(tickEvent); }
 		}
 		
-		Ticker.dispatchEvent({type:"tick", paused:paused, delta:elapsedTime, time:time, runTime:time-Ticker._pausedTime})
+		Ticker.dispatchEvent(tickEvent);
 		
 		Ticker._tickTimes.unshift(Ticker._getTime()-time);
 		while (Ticker._tickTimes.length > 100) { Ticker._tickTimes.pop(); }


### PR DESCRIPTION
In #250 I requested we add `totalElapsed` and `runTimeElapsed` as parameters to the "tick" event args (in addition to `elapsedTime` and `paused`).
However, I realized that `dispatchEvent` takes an event object that contains these parameters.  So, instead of calling `listener.tick(elapsedTime, paused, runTimeElapsed, totalElapsed)`, I've changed it to `listener.tick(tickEvent)`.

Unfortunately, this is a breaking change.  This is not a big concern for me and my project, but in order to maintain the majority of backwards functionality, I could also understand using `listener.tick(elapsedTime, tickDetails)`.
