### PR TITLE
First pass at EaselJS commonjs/node/npm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "EaselJS",
+    "description": "The Easel Javascript library provides a full, hierarchical display list, a core interaction model, and helper classes to make working with the HTML5 Canvas element much easier. Join the google group at http://groups.google.com/group/easeljs for discussion.",
+    "version": "0.5.0",
+    "homepage": "http://createjs.com/",
+    "main": "./src/common.js",
+    "engines": {
+        "node": "*",
+        "browsers": "*"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/CreateJS/EaselJS"
+    },
+    "author": {
+        "name": "gskinner",
+        "email": "",
+        "url": "gskinner.com"
+    },
+    "devDependencies": {},
+    "directories": {},
+    "readmeFilename": "README.md"
+}

--- a/src/common.js
+++ b/src/common.js
@@ -1,0 +1,61 @@
+var initialized,
+    hasDocument = typeof document !== 'undefined',
+    canvasSupported = hasDocument;
+
+function createCanvasError() {
+    throw new Error('createCanvas function is required when running in this context');
+}
+
+module.exports = function initalize(createCanvasFn) {
+    if (initialized) return initialized;
+
+    if (hasDocument) {
+        window.createjs = window.createjs || {};
+        try {
+            var canvas = document.createElement('canvas');
+            canvasSupported = !!(canvas.getContext && canvas.getContext('2d'));
+        } catch (e) {
+            canvasSupported = false;
+        }
+    } else {
+        global.window = global.window || global;
+        global.createjs = global.createjs || {};
+    }
+
+    createjs.createCanvas = (!canvasSupported && !createCanvasFn) ? createCanvasError : createCanvasFn;
+
+    //require('./easeljs/utils/Log'); // no deps
+    require('./easeljs/utils/UID'); // no deps
+    require('./easeljs/events/EventDispatcher'); // no deps
+    require('./easeljs/utils/Ticker'); // ../events/EventDispatcher
+    require('./easeljs/events/MouseEvent'); // ./EventDispatcher
+    require('./easeljs/geom/Matrix2D'); // no deps
+    require('./easeljs/geom/Point'); // no deps
+    require('./easeljs/geom/Rectangle'); // no deps
+    require('./easeljs/ui/ButtonHelper'); // no deps
+    require('./easeljs/display/Shadow'); // no deps
+    require('./easeljs/display/Graphics'); // no deps
+    require('./easeljs/display/DisplayObject'); // ../EventDispatcher, ../utils/UID, ../geom/Matrix2D, ./Stage, , ../geom/point
+    require('./easeljs/display/Container'); // ./DisplayObject
+    require('./easeljs/display/Stage'); // ./DisplayObject, ./Container, ../events/MouseEvent
+    require('./easeljs/display/Bitmap'); // ./DisplayObject
+    require('./easeljs/display/BitmapAnimation'); // ./DisplayObject, ../events/EventDispatcher
+    require('./easeljs/display/Shape'); // ./DisplayObject, ./Graphics
+    require('./easeljs/display/Text'); // ./DisplayObject
+    require('./easeljs/display/SpriteSheet'); // ./DisplayObject, ../events/EventDispatcher, ../geom/Rectangle
+    require('./easeljs/utils/SpriteSheetUtils');
+    require('./easeljs/utils/SpriteSheetBuilder');
+    require('./easeljs/display/DOMElement'); // ./DisplayObject
+    require('./easeljs/filters/Filter'); // ../geom/Rectangle
+    require('./easeljs/filters/AlphaMapFilter'); // ./Filter, ../geom/Rectangle
+    require('./easeljs/filters/AlphaMaskFilter'); // ./Filter
+    require('./easeljs/filters/BoxBlurFilter'); // ./Filter, ../geom/Rectangle
+    require('./easeljs/filters/ColorFilter'); // ./Filter
+    require('./easeljs/filters/ColorMatrix'); // ./Filter
+    require('./easeljs/filters/ColorMatrixFilter'); // ./Filter
+    require('./easeljs/ui/Touch'); // no deps
+
+    // Prevent initializing again
+    initialized = createjs;
+    return initialized;
+};


### PR DESCRIPTION
I really don't think this is finished, but it is indeed functional.
You can actually test it out yourself. Go ahead and go into the node REPL, and do this:

``` javascript
var easeljs = require('./src/common')(function () {
    return {
        getContext: function () {
            return {}
        }
    }
});
```

What you pass there is just a Mock to createCanvas. I force createCanvas to be required if loaded without a document global. When running in node I just wanted to experiment to see if I could actually do something with this project https://github.com/LearnBoost/node-canvas, but haven't gotten that far yet.

I don't really like forcing an initializing phase, and it doesn't need to do this when canvas is available, but it was quick and dirty for now without making any changes to the actual code base. I just wanted to get thoughts and opinions on it first.

My ultimate goal was to see if I could use [Closure Compiler's commonjs options](http://www.nonblocking.io/2011/12/experimental-support-for-common-js-and.html) to compile a build, but also use modules for development in the browser without needing a compile with many of the module libraries out there now. The Closure Compiler commonjs build doesn't look like it's going to happen without making quite a few changes though :/

My belief is that if the dependencies were defined as modules (and installable through npm), and Closure Compiler would actually make it through a build like this, it would be bring a number of more developers to the project.
