### PR TITLE
The stage click handler does not properly ignore events outside it's bounds when x,y transforms are applied

### DIFF
--- a/src/easeljs/display/Stage.js
+++ b/src/easeljs/display/Stage.js
@@ -620,6 +620,8 @@ var p = Stage.prototype = new createjs.Container();
 	 **/
 	p._handlePointerDown = function(id, e, x, y) {
 		var o = this._getPointerData(id);
+		if (o.inBounds == false)
+			return;
 		if (y != null) { this._updatePointerPosition(id, x, y); }
 		
 		if (this.onMouseDown || this.hasEventListener("stagemousedown")) {
@@ -686,6 +688,8 @@ var p = Stage.prototype = new createjs.Container();
 	 **/
 	p._handleDoubleClick = function(e) {
 		var o = this._getPointerData(-1);
+		if (o.inBounds == false)
+				return;
 		var target = this._getObjectsUnderPoint(o.x, o.y, null, (this._mouseOverIntervalID ? 3 : 1));
 		if (target && (target.onDoubleClick || target.hasEventListener("dblclick"))) {
 			evt = new createjs.MouseEvent("dblclick", o.x, o.y, target, e, -1, true, o.rawX, o.rawY);


### PR DESCRIPTION
Consider this scenario. You have stage 1 and stage 2 side by side. Both have DisplayObjects which register for DblClick. In stage 2, you've set stage.x and stage.y so the coordinate space of the stage is shifted on top of stage 1's physical space. (I have a game where the two stages are showing different parts of the game world, side by side.) When you click on Stage 1, both stage 1 and stage 2 receive a double click event. When testing for a hit, the Stage class uses the event's X and Y, which have already had the transform applied. This causes the Stage 2 to think the hit occurred within it's bounds, even though the event's inBounds property is false, this value is never checked. 

End result: The click event fires for both Stage 1 and Stage 2, even though the click was outside Stage 2.

Adding a simple check for inBounds in the hit testing functions fixed the issue. Tiny commit!
- Ben
