### PR TITLE
it's/its

### DIFF
--- a/examples/BarGraph.html
+++ b/examples/BarGraph.html
@@ -85,7 +85,7 @@
 
 		// draw the bars:
 		for (i=0; i<numBars; i++) {
-			// each bar is assembled in it's own Container, to make them easier to work with:
+			// each bar is assembled in its own Container, to make them easier to work with:
 			var bar = new createjs.Container();
 
 			// this will determine the color of each bar, save as a property of the bar for use in drawBar:

--- a/examples/DragAndDrop.html
+++ b/examples/DragAndDrop.html
@@ -81,7 +81,7 @@
 			// wrapper function to provide scope for the event handlers:
 			(function(target) {
 				bitmap.onPress = function(evt) {
-					// bump the target in front of it's siblings:
+					// bump the target in front of its siblings:
 					container.addChild(target);
 					var offset = {x:target.x-evt.stageX, y:target.y-evt.stageY};
 

--- a/examples/DragAndDrop_EventDispatcher.html
+++ b/examples/DragAndDrop_EventDispatcher.html
@@ -80,7 +80,7 @@
 			bitmap.cursor = "pointer";
 
 			bitmap.addEventListener("mousedown", function(evt) {
-				// bump the target in front of it's siblings:
+				// bump the target in front of its siblings:
 				var o = evt.target;
 				o.parent.addChild(o);
 				var offset = {x:o.x-evt.stageX, y:o.y-evt.stageY};

--- a/examples/DragAndDrop_hitArea.html
+++ b/examples/DragAndDrop_hitArea.html
@@ -95,7 +95,7 @@
 			// wrapper function to provide scope for the event handlers:
 			(function(target) {
 				bitmap.onPress = function(evt) {
-					// bump the target in front of it's siblings:
+					// bump the target in front of its siblings:
 					container.addChild(target);
 					var offset = {x:target.x-evt.stageX, y:target.y-evt.stageY};
 

--- a/examples/HelloWorld.html
+++ b/examples/HelloWorld.html
@@ -30,7 +30,7 @@
 		var text = new createjs.Text("Hello World!", "36px Arial", "#777");
 
 		// add the text as a child of the stage. This means it will be drawn any time the stage is updated
-		// and that it's transformations will be relative to the stage coordinates:
+		// and that its transformations will be relative to the stage coordinates:
 		stage.addChild(text);
 
 		// position the text on screen, relative to the stage coordinates:

--- a/src/easeljs/display/Bitmap.js
+++ b/src/easeljs/display/Bitmap.js
@@ -125,7 +125,7 @@ var p = Bitmap.prototype = new createjs.DisplayObject();
 	p.DisplayObject_draw = p.draw;
 
 	/**
-	 * Draws the display object into the specified context ignoring it's visible, alpha, shadow, and transform.
+	 * Draws the display object into the specified context ignoring its visible, alpha, shadow, and transform.
 	 * Returns true if the draw was handled (useful for overriding functionality).
 	 *
 	 * NOTE: This method is mainly for internal use, though it may be useful for advanced uses.

--- a/src/easeljs/display/Container.js
+++ b/src/easeljs/display/Container.js
@@ -110,7 +110,7 @@ var p = Container.prototype = new createjs.DisplayObject();
 	p.DisplayObject_draw = p.draw;
 
 	/**
-	 * Draws the display object into the specified context ignoring it's visible, alpha, shadow, and transform.
+	 * Draws the display object into the specified context ignoring its visible, alpha, shadow, and transform.
 	 * Returns true if the draw was handled (useful for overriding functionality).
 	 *
 	 * NOTE: This method is mainly for internal use, though it may be useful for advanced uses.

--- a/src/easeljs/display/DOMElement.js
+++ b/src/easeljs/display/DOMElement.js
@@ -123,7 +123,7 @@ var p = DOMElement.prototype = new createjs.DisplayObject();
 	}
 
 	/**
-	 * Draws the display object into the specified context ignoring it's visible, alpha, shadow, and transform.
+	 * Draws the display object into the specified context ignoring its visible, alpha, shadow, and transform.
 	 * Returns true if the draw was handled (useful for overriding functionality).
 	 * NOTE: This method is mainly for internal use, though it may be useful for advanced uses.
 	 * @method draw

--- a/src/easeljs/display/DisplayObject.js
+++ b/src/easeljs/display/DisplayObject.js
@@ -281,7 +281,7 @@ var p = DisplayObject.prototype;
 
 	/**
 	 * The x offset for this display object's registration point. For example, to make a 100x100px Bitmap rotate around
-	 * it's center, you would set regX and regY to 50.
+	 * its center, you would set regX and regY to 50.
 	 * @property regX
 	 * @type {Number}
 	 * @default 0
@@ -290,7 +290,7 @@ var p = DisplayObject.prototype;
 
 	/**
 	 * The y offset for this display object's registration point. For example, to make a 100x100px Bitmap rotate around
-	 * it's center, you would set regX and regY to 50.
+	 * its center, you would set regX and regY to 50.
 	 * @property regY
 	 * @type {Number}
 	 * @default 0
@@ -307,7 +307,7 @@ var p = DisplayObject.prototype;
 
 	/**
 	 * The factor to stretch this display object horizontally. For example, setting scaleX to 2 will stretch the display
-	 * object to twice it's nominal width. To horizontally flip an object, set the scale to a negative number.
+	 * object to twice its nominal width. To horizontally flip an object, set the scale to a negative number.
 	 * @property scaleX
 	 * @type {Number}
 	 * @default 1
@@ -316,7 +316,7 @@ var p = DisplayObject.prototype;
 
 	/**
 	 * The factor to stretch this display object vertically. For example, setting scaleY to 0.5 will stretch the display
-	 * object to half it's nominal height. To vertically flip an object, set the scale to a negative number.
+	 * object to half its nominal height. To vertically flip an object, set the scale to a negative number.
 	 * @property scaleY
 	 * @type {Number}
 	 * @default 1
@@ -384,7 +384,7 @@ var p = DisplayObject.prototype;
 	p.compositeOperation = null;
 
 	/**
-	 * Indicates whether the display object should have it's x & y position rounded prior to drawing it to stage.
+	 * Indicates whether the display object should have its x & y position rounded prior to drawing it to stage.
 	 * Snapping to whole pixels can result in a sharper and faster draw for images (ex. Bitmap & cached objects).
 	 * This only applies if the enclosing stage has snapPixelsEnabled set to true. The snapToPixel property is true
 	 * by default for Bitmap and Sprite instances, and false for all other display objects.
@@ -602,7 +602,7 @@ var p = DisplayObject.prototype;
 	};
 
 	/**
-	 * Draws the display object into the specified context ignoring it's visible, alpha, shadow, and transform.
+	 * Draws the display object into the specified context ignoring its visible, alpha, shadow, and transform.
 	 * Returns <code>true</code> if the draw was handled (useful for overriding functionality).
 	 *
 	 * NOTE: This method is mainly for internal use, though it may be useful for advanced uses.
@@ -652,7 +652,7 @@ var p = DisplayObject.prototype;
 	 * Draws the display object into a new canvas, which is then used for subsequent draws. For complex content
 	 * that does not change frequently (ex. a Container with many children that do not move, or a complex vector Shape),
 	 * this can provide for much faster rendering because the content does not need to be re-rendered each tick. The
-	 * cached display object can be moved, rotated, faded, etc freely, however if it's content changes, you must
+	 * cached display object can be moved, rotated, faded, etc freely, however if its content changes, you must
 	 * manually update the cache by calling <code>updateCache()</code> or <code>cache()</code> again. You must specify
 	 * the cache area via the x, y, w, and h parameters. This defines the rectangle that will be rendered and cached
 	 * using this display object's coordinates.

--- a/src/easeljs/display/Graphics.js
+++ b/src/easeljs/display/Graphics.js
@@ -369,7 +369,7 @@ var p = Graphics.prototype;
 	};
 	
 	/**
-	 * Draws the display object into the specified context ignoring it's visible, alpha, shadow, and transform.
+	 * Draws the display object into the specified context ignoring its visible, alpha, shadow, and transform.
 	 * Returns true if the draw was handled (useful for overriding functionality).
 	 *
 	 * NOTE: This method is mainly for internal use, though it may be useful for advanced uses.

--- a/src/easeljs/display/MovieClip.js
+++ b/src/easeljs/display/MovieClip.js
@@ -106,7 +106,7 @@ var p = MovieClip.prototype = new createjs.Container();
 	MovieClip.SINGLE_FRAME = "single";
 	
 	/**
-	 * Read-only. The MovieClip will be advanced only when it's parent advances and will be synched to the position of
+	 * Read-only. The MovieClip will be advanced only when its parent advances and will be synched to the position of
 	 * the parent MovieClip.
 	 * @property SYNCHED
 	 * @static
@@ -291,7 +291,7 @@ var p = MovieClip.prototype = new createjs.Container();
 	p.Container_draw = p.draw;
 	
 	/**
-	 * Draws the display object into the specified context ignoring it's visible, alpha, shadow, and transform.
+	 * Draws the display object into the specified context ignoring its visible, alpha, shadow, and transform.
 	 * Returns true if the draw was handled (useful for overriding functionality).
 	 * NOTE: This method is mainly for internal use, though it may be useful for advanced uses.
 	 * @method draw

--- a/src/easeljs/display/Shadow.js
+++ b/src/easeljs/display/Shadow.js
@@ -33,7 +33,7 @@ this.createjs = this.createjs||{};
 
 /**
  * This class encapsulates the properties required to define a shadow to apply to a {{#crossLink "DisplayObject"}}{{/crossLink}}
- * via it's <code>shadow</code> property.
+ * via its <code>shadow</code> property.
  *
  * <h4>Example</h4>
  *      myImage.shadow = new createjs.Shadow("#000000", 5, 5, 10);

--- a/src/easeljs/display/Shape.js
+++ b/src/easeljs/display/Shape.js
@@ -105,7 +105,7 @@ var p = Shape.prototype = new createjs.DisplayObject();
 	p.DisplayObject_draw = p.draw;
 	
 	/**
-	 * Draws the Shape into the specified context ignoring it's visible, alpha, shadow, and transform. Returns true if
+	 * Draws the Shape into the specified context ignoring its visible, alpha, shadow, and transform. Returns true if
 	 * the draw was handled (useful for overriding functionality).
 	 *
 	 * <i>NOTE: This method is mainly for internal use, though it may be useful for advanced uses.</i>

--- a/src/easeljs/display/Sprite.js
+++ b/src/easeljs/display/Sprite.js
@@ -240,7 +240,7 @@ var p = Sprite.prototype = new createjs.DisplayObject();
 	p.DisplayObject_draw = p.draw;
 
 	/**
-	 * Draws the display object into the specified context ignoring it's visible, alpha, shadow, and transform.
+	 * Draws the display object into the specified context ignoring its visible, alpha, shadow, and transform.
 	 * Returns true if the draw was handled (useful for overriding functionality).
 	 * NOTE: This method is mainly for internal use, though it may be useful for advanced uses.
 	 * @method draw

--- a/src/easeljs/display/Text.js
+++ b/src/easeljs/display/Text.js
@@ -193,7 +193,7 @@ var p = Text.prototype = new createjs.DisplayObject();
 	p.DisplayObject_draw = p.draw;
 	
 	/**
-	 * Draws the Text into the specified context ignoring it's visible, alpha, shadow, and transform.
+	 * Draws the Text into the specified context ignoring its visible, alpha, shadow, and transform.
 	 * Returns true if the draw was handled (useful for overriding functionality).
 	 * NOTE: This method is mainly for internal use, though it may be useful for advanced uses.
 	 * @method draw

--- a/src/easeljs/utils/SpriteSheetBuilder.js
+++ b/src/easeljs/utils/SpriteSheetBuilder.js
@@ -235,7 +235,7 @@ var p = SpriteSheetBuilder.prototype;
 	 * Adds a frame to the {{#crossLink "SpriteSheet"}}{{/crossLink}}. Note that the frame will not be drawn until you
 	 * call {{#crossLink "SpriteSheetBuilder/build"}}{{/crossLink}} method. The optional setup params allow you to have
 	 * a function run immediately before the draw occurs. For example, this allows you to add a single source multiple
-	 * times, but manipulate it or it's children to change it to generate different frames.
+	 * times, but manipulate it or its children to change it to generate different frames.
 	 *
 	 * Note that the source's transformations (x, y, scale, rotate, alpha) will be ignored, except for regX/Y. To apply
 	 * transforms to a source object and have them captured in the sprite sheet, simply place it into a {{#crossLink "Container"}}{{/crossLink}}


### PR DESCRIPTION
Correcting the usage of it's/its in appropriate places. I have not rebuilt the documentation with these changes.
