### PR TITLE
[fixed #365] Used new implementation for new Image

### DIFF
--- a/src/easeljs/display/Bitmap.js
+++ b/src/easeljs/display/Bitmap.js
@@ -108,7 +108,7 @@ var p = Bitmap.prototype = new createjs.DisplayObject();
 	p.initialize = function(imageOrUri) {
 		this.DisplayObject_initialize();
 		if (typeof imageOrUri == "string") {
-			this.image = new Image();
+			this.image = document.createElement("img");
 			this.image.src = imageOrUri;
 		} else {
 			this.image = imageOrUri;

--- a/src/easeljs/display/SpriteSheet.js
+++ b/src/easeljs/display/SpriteSheet.js
@@ -258,7 +258,7 @@ var p = SpriteSheet.prototype = new createjs.EventDispatcher();
 				var img = data.images[i];
 				if (typeof img == "string") {
 					var src = img;
-					img = new Image();
+					img = document.createElement("img");
 					img.src = src;
 				}
 				a.push(img);

--- a/src/easeljs/utils/SpriteSheetUtils.js
+++ b/src/easeljs/utils/SpriteSheetUtils.js
@@ -129,7 +129,7 @@ var SpriteSheetUtils = function() {
 		canvas.width = r.width;
 		canvas.height = r.height;
 		SpriteSheetUtils._workingContext.drawImage(data.image, r.x, r.y, r.width, r.height, 0, 0, r.width, r.height);
-		var img = new Image();
+		var img = document.createElement("img");
 		img.src = canvas.toDataURL("image/png");
 		return img;
 	};
@@ -176,7 +176,7 @@ var SpriteSheetUtils = function() {
 			canvas.height = src.height;
 			ctx.setTransform(h?-1:1, 0, 0, v?-1:1, h?src.width:0, v?src.height:0);
 			ctx.drawImage(src,0,0);
-			var img = new Image();
+			var img = document.createElement("img");
 			img.src = canvas.toDataURL("image/png");
 			// work around a strange bug in Safari:
 			img.width = src.width;


### PR DESCRIPTION
Replaced `new Image()` with `document.createElement("img")`. 
See issue #365.
