### PR TITLE
Fixes bug where Ticker.getMeasuredTickTime() return NaN

### DIFF
--- a/src/easeljs/utils/Ticker.js
+++ b/src/easeljs/utils/Ticker.js
@@ -383,7 +383,7 @@ var Ticker = function() {
 		// by default, calculate average for the past ~1 second:
 		ticks = Math.min(times.length, ticks||(Ticker.getFPS()|0));
 		for (var i=0; i<ticks; i++) { ttl += times[i]; }
-		return times/ticks;
+		return ttl/ticks;
 	};
 
 	/**


### PR DESCRIPTION
Pull request to fix bug where Ticker.getMeasuredTickTime() return NaN.
Please, see the issue #387 for more details.
