### PR TITLE
add option to avoid hitArea calculations for Bitmap instances avoiding cross domain errors and unecessary expensive calculations.

### DIFF
--- a/src/easeljs/display/Container.js
+++ b/src/easeljs/display/Container.js
@@ -587,6 +587,9 @@ var p = Container.prototype = new createjs.DisplayObject();
 					mtx.alpha = hitArea.alpha;
 				}
 				
+				// if avoidBitmapHitAreaCalculation is true, doesen't calculate hitArea for bitmaps istances avoiding cross domain errors and unecessary processing.
+				if (createjs.DisplayObject.avoidBitmapHitAreaCalculation == true && child instanceof createjs.Bitmap && !hitArea) return null;
+
 				ctx.globalAlpha = mtx.alpha;
 				ctx.setTransform(mtx.a,  mtx.b, mtx.c, mtx.d, mtx.tx-x, mtx.ty-y);
 				(hitArea||child).draw(ctx);

--- a/src/easeljs/display/DisplayObject.js
+++ b/src/easeljs/display/DisplayObject.js
@@ -148,6 +148,16 @@ var p = DisplayObject.prototype = new createjs.EventDispatcher();
 	DisplayObject.suppressCrossDomainErrors = false;
 
 	/**
+	 * Avoid hitArea calculations for Bitmap instances avoiding cross domain errors and unecessary expensive calculations.
+	 * If is true, all bitmap instances shall have defined hitArea for mouse/touch interacions.
+	 * @property avoidBitmapHitAreaCalculation
+	 * @static
+	 * @type {Boolean}
+	 * @default false
+	 **/
+	DisplayObject.avoidBitmapHitAreaCalculation = false;
+	
+	/**
 	 * @property _hitTestCanvas
 	 * @type {HTMLCanvasElement | Object}
 	 * @static


### PR DESCRIPTION
Added a static DisplayObject option to avoid automatically hitArea calculations for Bitmap instances avoiding cross domain errors and unecessary expensive calculations.

```
DisplayObject.avoidBitmapHitAreaCalculation = false;
```

If is true, all bitmap instances shall have defined hitArea for mouse/touch interacions.
