### PR TITLE
Incorrect using reference was fixed

### DIFF
--- a/examples/CurveTo.html
+++ b/examples/CurveTo.html
@@ -86,7 +86,7 @@
             color = colors[(index++)%colors.length];
             stroke = Math.random()*30 + 10 | 0;
             oldPt = new createjs.Point(stage.mouseX, stage.mouseY);
-            oldMidPt = oldPt;
+            oldMidPt = new createjs.Point(oldPt.x, oldPt.y);
             stage.addEventListener("stagemousemove" , handleMouseMove);
         }
 


### PR DESCRIPTION
Hello. I'm started using easeljs and modified one of your examples. In particular case (with stroke = 1 and green color on white background) line looks less smoothly than in my variant. This is not a problem in your example because you have really thick pen, but you may fix it. You incorrectly initialized object with a reference instead of creating an object.
You may replace 
oldPt = new createjs.Point(stage.mouseX, stage.mouseY);
oldMidPt = oldPt;
with
oldPt = new createjs.Point(stage.mouseX, stage.mouseY);
oldMidPt = new createjs.Point(oldPt.x, oldPt.y);

You can modify handleMouseMove by adding console.log("oldMidPt are equals oldPt: " + (oldMidPt === oldPt)) as here and you'll see the problem:

function handleMouseMove(event) {
            var midPt = new createjs.Point(oldPt.x + stage.mouseX>>1, oldPt.y+stage.mouseY>>1);

```
        drawingCanvas.graphics.clear().setStrokeStyle(stroke, 'round', 'round').beginStroke(color).moveTo(midPt.x, midPt.y).curveTo(oldPt.x, oldPt.y, oldMidPt.x, oldMidPt.y);

        oldPt.x = stage.mouseX;
        oldPt.y = stage.mouseY;

        oldMidPt.x = midPt.x;
        oldMidPt.y = midPt.y;

        console.log("oldMidPt are equals oldPt: " + (oldMidPt === oldPt));

        stage.update();
    }
```
