### PR TITLE
Update gitignore to ignore docs subfolders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 build/output/
 build/tmp/
+docs/**/
 *TMP*
 node_modules/
 .idea/


### PR DESCRIPTION
I frequently find myself wanting to unzip the "next" version of the docs directly from the repo. I added a line to the gitignore file so that all subdirectories in the docs folder are ignored.
