### PR TITLE
Add WebGL undefined check to SpriteStage draw()

### DIFF
--- a/src/easeljs/display/SpriteStage.js
+++ b/src/easeljs/display/SpriteStage.js
@@ -529,7 +529,7 @@ SpriteStage.prototype.constructor = SpriteStage;
 	 * into itself).
 	 **/
 	p.draw = function(ctx, ignoreCache) {
-		if (ctx === this._webGLContext || ctx instanceof WebGLRenderingContext) {
+		if (typeof WebGLRenderingContext !== 'undefined' && (ctx === this._webGLContext || ctx instanceof WebGLRenderingContext)) {		
 			this._drawWebGLKids(this.children, ctx);
 
 			// If there is a remaining texture, draw it:


### PR DESCRIPTION
This was breaking Internet Explorer 10 support for us, https://github.com/codecombat/codecombat/issues/1620
