### PR TITLE
Tick fix (Important!)

### DIFF
--- a/src/easeljs/utils/Ticker.js
+++ b/src/easeljs/utils/Ticker.js
@@ -382,7 +382,7 @@ var Ticker = function() {
 	 **/
 	Ticker.getMeasuredTickTime = function(ticks) {
 		var ttl=0, times=Ticker._tickTimes;
-		if (times.length < 1) { return -1; }
+		if (!times || times.length < 1) { return -1; }
 
 		// by default, calculate average for the past ~1 second:
 		ticks = Math.min(times.length, ticks||(Ticker.getFPS()|0));
@@ -401,7 +401,7 @@ var Ticker = function() {
 	 **/
 	Ticker.getMeasuredFPS = function(ticks) {
 		var times = Ticker._times;
-		if (times.length < 2) { return -1; }
+		if (!times || times.length < 2) { return -1; }
 
 		// by default, calculate fps for the past ~1 second:
 		ticks = Math.min(times.length-1, ticks||(Ticker.getFPS()|0));


### PR DESCRIPTION
MAJOR: In commit bacb8a7, the `Ticker._lastTime = time` update was changed to `Ticker._lastTime = adjTime`, which is wrong - this results in wrong value on elapsedTime (thus, on event.delta).

MINOR(s): getMeasuredTickTime and getMeasuredFPS now verifies if times list is null, so if we call them before Ticker initialization, they don`t throw errors.
