### PR TITLE
Starter EditorConfig and jshint files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = tab
+indent_size = 2
+
+# We recommend you to keep these unchanged
+charset = utf-8
+# removed eol because git handles this
+# end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,23 @@
+{
+  "browser": true,
+  "esnext": true,
+  "bitwise": false,
+  "camelcase": false,
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "quotmark": "double",
+  "regexp": true,
+  "undef": true,
+  "unused": "vars",
+  "strict": true,
+  "trailing": true,
+  "smarttabs": true,
+  "globals": {
+  	"createjs": false
+  }
+}


### PR DESCRIPTION
I like both of these tools

EditorConfig helps many people use the same indentation style and does some whitespace trimming.  

Static analysis (jshint) I almost consider a must these days, although there's on-boarding work (there will be lots of flags thrown up in the current source).

I'm not trying to put forward a particular style (tabs vs spaces for instance;  I actually usually use spaces).   I made a starting place from existing files I has with some changes to reflect what I see in the easeljs source.  
