### PR TITLE
Update DisplayObject.js

### DIFF
--- a/src/easeljs/display/DisplayObject.js
+++ b/src/easeljs/display/DisplayObject.js
@@ -1163,8 +1163,8 @@ this.createjs = this.createjs||{};
 	 * @param {Number} height The height of the bounds.
 	 **/
 	p.setBounds = function(x, y, width, height) {
-		if (x == null) { this._bounds = x; }
-		this._bounds = (this._bounds || new createjs.Rectangle()).setValues(x, y, width, height);
+		if (x == null) { this._bounds = null; }
+		else { this._bounds = (this._bounds || new createjs.Rectangle()).setValues(x, y, width, height); }
 	};
 
 	/**


### PR DESCRIPTION
Fix: case setBounds(null)  (don't do "this._bounds = new createjs.Rectangle" after "this._bounds = null").
Maybe we need also always create new rectangle, not using old _bounds (or always return cloned rectangle from getBounds())?
In my project I got several bugs related to next code:
var boundsToUseLater = myObj.getBounds(); // save current bounds
// some code (change myObj then call getBounds())
// use boundsToUseLater - properties x/y/widht/height not the same as they were the save moment
