### PR TITLE
Fix Text's .getBounds() returning null when text is 0

### DIFF
--- a/src/easeljs/display/Text.js
+++ b/src/easeljs/display/Text.js
@@ -253,7 +253,7 @@ this.createjs = this.createjs||{};
 	p.getBounds = function() {
 		var rect = this.DisplayObject_getBounds();
 		if (rect) { return rect; }
-		if (this.text == null || this.text == "") { return null; }
+		if (this.text === null || this.text === "") { return null; }
 		var o = this._drawText(null, {});
 		var w = (this.maxWidth && this.maxWidth < o.width) ? this.maxWidth : o.width;
 		var x = w * Text.H_OFFSETS[this.textAlign||"left"];


### PR DESCRIPTION
Fixes this issue: https://github.com/CreateJS/EaselJS/issues/550

Basically:
* 0 == "" // true
* 0 === "" // false

Other way it could be dealt with is by converting to string.
```
this.text = String(text);
```

