### PR TITLE
Fix mouseup/mousedown event handler, not working properly with different mouse buttons

### DIFF
--- a/src/easeljs/display/Stage.js
+++ b/src/easeljs/display/Stage.js
@@ -702,7 +702,7 @@ this.createjs = this.createjs||{};
 	 * @param {MouseEvent} e
 	 **/
 	p._handleMouseUp = function(e) {
-		this._handlePointerUp(-1, e, false);
+		this._handlePointerUp(event.button, e, false);
 	};
 
 	/**
@@ -739,7 +739,7 @@ this.createjs = this.createjs||{};
 	 * @param {MouseEvent} e
 	 **/
 	p._handleMouseDown = function(e) {
-		this._handlePointerDown(-1, e, e.pageX, e.pageY);
+		this._handlePointerDown(event.button, e, e.pageX, e.pageY);
 	};
 
 	/**


### PR DESCRIPTION
Fixing this issue: https://github.com/CreateJS/EaselJS/issues/551

By setting the id with the mouse button, it will end up with a separate object for each button. Before the same object would be reused regardless of what mouse button was pressed.

Test I used:
```
// ...
circle.addEventListener('pressup', function(event)
    {
    console.log(event.type, event.nativeEvent.which);
    });
circle.addEventListener('mousedown', function(event)
    {
    console.log(event.type, event.nativeEvent.which);
    });
stage.addEventListener('stagemouseup', function(event)
    {
    console.log(event.type, event.nativeEvent.which);
    });
// ...
```
Press the mouse button and the middle mouse button at same time, then release them.
Before this patch you get:
```
mousedown 1
mousedown 2
stagemouseup 2
pressup 2
```

After:
```
mousedown 1
mousedown 2
stagemouseup 2
pressup 2
stagemouseup 1
pressup 1
```