### PR TITLE
:memo: object is not helpful

### DIFF
--- a/src/easeljs/display/Stage.js
+++ b/src/easeljs/display/Stage.js
@@ -94,7 +94,7 @@ this.createjs = this.createjs||{};
 		 *      myStage.enableDOMEvents(true);
 		 *
 		 * @property canvas
-		 * @type HTMLCanvasElement | Object
+		 * @type HTMLCanvasElement
 		 **/
 		this.canvas = (typeof canvas == "string") ? document.getElementById(canvas) : canvas;
 	


### PR DESCRIPTION
it made its way to https://github.com/borisyankov/DefinitelyTyped/blob/master/easeljs/easeljs.d.ts#L872 and having `object` there makes it difficult for people to do `canvas.height` etc.