### PR TITLE
Add Ticker._pausedTime in Ticker.reset()

### DIFF
--- a/src/createjs/utils/Ticker.js
+++ b/src/createjs/utils/Ticker.js
@@ -415,7 +415,7 @@ this.createjs = this.createjs||{};
 		}
 		Ticker.removeAllEventListeners("tick");
 		Ticker._timerId = Ticker._times = Ticker._tickTimes = null;
-		Ticker._startTime = Ticker._lastTime = Ticker._ticks = 0;
+		Ticker._startTime = Ticker._lastTime = Ticker._ticks = Ticker._pausedTime = 0;
 		Ticker._inited = false;
 	};
 


### PR DESCRIPTION
Hi :)

I add pausedTime in Ticker.reset().
If pausedTime  does not initialize in reset(), `createjs.Ticker.getEventTime(true))` returns minus number.
[getEventTime]
(https://github.com/CreateJS/EaselJS/blob/d5d9e9feec5a02f062d4a803037e8f96b8d39410/src/createjs/utils/Ticker.js#L513-L515)

thanks.