### PR TITLE
Commit b5e0fbe caused a change in behavior when calling decompose()

### DIFF
--- a/src/easeljs/geom/Matrix2D.js
+++ b/src/easeljs/geom/Matrix2D.js
@@ -494,7 +494,7 @@ this.createjs = this.createjs||{};
 		var skewX = Math.atan2(-this.c, this.d);
 		var skewY = Math.atan2(this.b, this.a);
 
-		var delta = Math.abs(1-skewX/skewY);
+		var delta = isNaN(skewX/skewY) ? 0 : Math.abs(1-skewX/skewY);
 		if (delta < 0.00001) { // effectively identical, can use rotation:
 			target.rotation = skewY/Matrix2D.DEG_TO_RAD;
 			if (this.a < 0 && this.d >= 0) {


### PR DESCRIPTION
Originally an identity matrix would produce a rotation of 0 and no skewX/skewY
after the change it has a skeyX and skewY of 0 and no rotation.
This reverts the results to what they were originally
