### PR TITLE
Fix error when drawing DOMElement with SpriteStage

### DIFF
--- a/src/easeljs/display/SpriteStage.js
+++ b/src/easeljs/display/SpriteStage.js
@@ -821,7 +821,9 @@ this.createjs = this.createjs||{};
 			if (!kid.isVisible()) { continue; }
 			
 			// Get the texture for this display branch:
-			var image = kid.image || (kid.spriteSheet && kid.spriteSheet._images[0]), texture = image.__easeljs_texture;
+			var image = kid.image || (kid.spriteSheet && kid.spriteSheet._images[0]);
+			if (!image) { continue; } // kid that doesn't have image (ex. DOMElement).
+			var texture = image.__easeljs_texture;
 			if (!texture && !(texture = this._setupImageTexture(ctx, image))) { continue; } // no texture available (ex. may not be loaded yet).
 			
 			mtx = kid._props.matrix;


### PR DESCRIPTION
due to cec2828, _drawWebGLKids start to throw error when getting the
texture from the DOMElement kid.