### PR TITLE
Fix DOMElement for retina screens

### DIFF
--- a/src/easeljs/display/DOMElement.js
+++ b/src/easeljs/display/DOMElement.js
@@ -36,6 +36,24 @@ this.createjs = this.createjs||{};
 (function() {
 	"use strict";
 
+	// @todo - Move into separate file.
+	function BrowserDetect() {
+		throw "BrowserDetect cannot be instantiated.";
+	}
+
+	// Returns 2 on a retina macbook pro for example.
+	BrowserDetect.getDevicePixelRatio = function() {
+		var ratio = 1;
+    // To account for zoom, change to use deviceXDPI instead of systemXDPI
+    if (window.screen.systemXDPI != null && window.screen.logicalXDPI != null && window.screen.systemXDPI > window.screen.logicalXDPI) {
+      // Only allow for values > 1
+    	ratio = window.screen.systemXDPI / window.screen.logicalXDPI;
+    } else if (window.devicePixelRatio != null) {
+      ratio = window.devicePixelRatio;
+    }
+    return ratio;
+	}
+
 
 // constructor:
 	/**
@@ -97,6 +115,7 @@ this.createjs = this.createjs||{};
 		 * @protected
 		 */
 		this._oldProps = null;
+		this._devicePixelRatio = BrowserDetect.getDevicePixelRatio();
 	}
 	var p = createjs.extend(DOMElement, createjs.DisplayObject);
 
@@ -255,9 +274,9 @@ this.createjs = this.createjs||{};
 		var n = 10000; // precision
 		
 		if (!oldMtx || !oldMtx.equals(mtx)) {
-			var str = "matrix(" + (mtx.a*n|0)/n +","+ (mtx.b*n|0)/n +","+ (mtx.c*n|0)/n +","+ (mtx.d*n|0)/n +","+ (mtx.tx+0.5|0);
-			style.transform = style.WebkitTransform = style.OTransform = style.msTransform = str +","+ (mtx.ty+0.5|0) +")";
-			style.MozTransform = str +"px,"+ (mtx.ty+0.5|0) +"px)";
+			var str = "matrix(" + (mtx.a*n|0)/n/this._devicePixelRatio +","+ (mtx.b*n|0)/n +","+ (mtx.c*n|0)/n +","+ (mtx.d*n|0)/n/this._devicePixelRatio +","+ (mtx.tx+0.5|0)/this._devicePixelRatio;
+			style.transform = style.WebkitTransform = style.OTransform = style.msTransform = str +","+ (mtx.ty+0.5|0)/this._devicePixelRatio +")";
+			style.MozTransform = str +"px,"+ (mtx.ty+0.5|0)/this._devicePixelRatio +"px)";
 			if (!oldProps) { oldProps = this._oldProps = new createjs.DisplayProps(true, NaN); }
 			oldProps.matrix.copy(mtx);
 		}


### PR DESCRIPTION
This fixes DOMElement for retina screens.

For example if you make your canvas retina aware like this:
``
var width = 900
var height = 400
var canvas = document.getElementById("canvas");
canvas.style.width = width
canvas.style.height = height
canvas.width = width * devicePixelRatio // value of devicePixelRatio can be seen in the code from BrowserDetect.getDeviceRatio()
canvas.height = height * devicePixelRatio
``

Then the Easel stage is rendered with crisp text and vector shapes on your retina screen, but DOMElement is positioned and scaled incorrectly.
This PR fixes that.
