### PR TITLE
Added pause check in MovieClip.__tick

### DIFF
--- a/src/easeljs/display/MovieClip.js
+++ b/src/easeljs/display/MovieClip.js
@@ -504,8 +504,10 @@ this.createjs = this.createjs||{};
 	 * @protected
 	 **/
 	p._tick = function(evtObj) {
+            if (!this.paused) {
 		this.advance(evtObj&&evtObj.delta);
-		this.Container__tick(evtObj);
+            }
+	    this.Container__tick(evtObj);
 	};
 	
 	/**


### PR DESCRIPTION
Recently while updating from 0.7.0 to 0.8.1, we noticed some occasional odd behaviour with MovieClips.
The issue is showcased in this fiddle, http://jsfiddle.net/z4mfq25j/1/

Essentially movieclips that are supposed to be stopped, sometimes play through once before looping and then stopping. It seems a check for `this.paused` has gone missing from the __tick method of MovieClip, compared to the 0.7.0 version, seemingly from refactoring and the addition of the `advance` method which did not previously exist.
This PR adds it again, and solves the issue for us, but is not extensively tested.