### PR TITLE
Corrected drag tutorial.

### DIFF
--- a/tutorials/Mouse Interaction/drag.html
+++ b/tutorials/Mouse Interaction/drag.html
@@ -25,11 +25,17 @@
 			dragger.x = dragger.y = 100;
 			dragger.addChild(circle, label);
 			stage.addChild(dragger);
+
+			dragger.on("mousedown", function (evt) {
+				// keep a record on the offset between the mouse position and the container
+				// position. currentTarget will be the container that the event listener was added to:
+				evt.currentTarget.offset = {x: this.x - evt.stageX, y: this.y - evt.stageY};
+			});
 			
 			dragger.on("pressmove",function(evt) {
-				// currentTarget will be the container that the event listener was added to:
-				evt.currentTarget.x = evt.stageX;
-				evt.currentTarget.y = evt.stageY;
+				// Calculate the new X and Y based on the mouse new position plus the offset.
+				evt.currentTarget.x = evt.stageX + evt.currentTarget.offset.x;
+				evt.currentTarget.y = evt.stageY + evt.currentTarget.offset.y;
 				// make sure to redraw the stage to show the change:
 				stage.update();   
 			});

--- a/tutorials/Mouse Interaction/index.html
+++ b/tutorials/Mouse Interaction/index.html
@@ -221,9 +221,12 @@ stage.on("stagemousemove", function(evt) {
 				which point a <code>pressup</code> event will be dispatched.
 			</p>
 			<textarea class="brush: js;" readonly>
+circle.on("mousedown"), function(evt) {
+	evt.target.offset = {x: this.x - evt.stageX, y: this.y - evt.stageY};
+}
 circle.on("pressmove", function(evt) {
-	evt.target.x = evt.stageX;
-	evt.target.y = evt.stageY;
+	evt.target.x = evt.stageX + evt.target.offset.x;
+	evt.target.y = evt.stageY + evt.target.offset.y;
 });
 circle.on("pressup", function(evt) { console.log("up"); })
 			</textarea>


### PR DESCRIPTION
The old code would center the circle on the mouse on mousedown.
This new code is the same on the drag example of the site.

Just for ease of discussion, here is the website demo relevant part:

```
    // using "on" binds the listener to the scope of the currentTarget by default
    // in this case that means it executes in the scope of the button.
    bitmap.on("mousedown", function (evt) {
        this.parent.addChild(this);
        this.offset = {x: this.x - evt.stageX, y: this.y - evt.stageY};
    });

    // the pressmove event is dispatched when the mouse moves after a mousedown on the target until the mouse is released.
    bitmap.on("pressmove", function (evt) {
        this.x = evt.stageX + this.offset.x;
        this.y = evt.stageY + this.offset.y;
        // indicate that the stage should be updated on the next tick:
        update = true;
    });

    bitmap.on("rollover", function (evt) {
        this.scaleX = this.scaleY = this.scale * 1.2;
        update = true;
    });

    bitmap.on("rollout", function (evt) {
        this.scaleX = this.scaleY = this.scale;
        update = true;
    });
```
