### PR TITLE
Fix for BitmapText when sprites has regX different from 0

### DIFF
--- a/src/easeljs/display/BitmapText.js
+++ b/src/easeljs/display/BitmapText.js
@@ -323,11 +323,12 @@ this.createjs = this.createjs || {};
 			}
 			sprite.spriteSheet = ss;
 			sprite.gotoAndStop(index);
-			sprite.x = x;
+			var spriteBounds = sprite.getBounds();
+			sprite.x = x - spriteBounds.x;
 			sprite.y = y;
 			childIndex++;
 			
-			x += sprite.getBounds().width + this.letterSpacing;
+			x += spriteBounds.width + this.letterSpacing;
 		}
 		while (numKids > childIndex) {
 			 // faster than removeChild.


### PR DESCRIPTION
Sprite.regX is considered when character is drawed but not in the x shift for the next letter. The solution is to draw the letter without the regX shift (without the transparent space left)