### PR TITLE
Use Object.getPrototypeof to get a hold of prototype object

### DIFF
--- a/lib/easeljs-0.8.2.combined.js
+++ b/lib/easeljs-0.8.2.combined.js
@@ -48,7 +48,7 @@ this.createjs = this.createjs||{};
  *
  * 	var foo = new MySubClass();
  * 	console.log(foo instanceof MySuperClass); // true
- * 	console.log(foo.prototype.constructor === MySubClass); // true
+ * 	console.log(Object.getPrototypeOf(foo).constructor === MySubClass);// true
  *
  * @method extend
  * @param {Function} subclass The subclass.


### PR DESCRIPTION
Fixed Simple typo: javascript object does not have a prototype property, rather use the Object.getPrototypeof to get hold of the  prototype object and then access the constructor property. (Line#: 51)