### PR TITLE
Internet Explorer cursor fix

### DIFF
--- a/src/easeljs/display/Stage.js
+++ b/src/easeljs/display/Stage.js
@@ -800,10 +800,11 @@ this.createjs = this.createjs||{};
 		var list = this._mouseOverTarget = [];
 
 		// generate ancestor list and check for cursor:
+		// Note: Internet Explorer won't update null or undefined cursor properties
 		t = target;
 		while (t) {
 			list.unshift(t);
-			if (!cursor) { cursor = t.cursor; }
+			if (!cursor && t.cursor) { cursor = t.cursor; }
 			t = t.parent;
 		}
 		this.canvas.style.cursor = cursor;


### PR DESCRIPTION
Internet Explorer doesn't update cursor style if it is null or undefined.  Chrome and Firefox seem to handle this with no problem.

Here's a [jsfiddle](https://jsfiddle.net/n3ztcqzb/) demonstrating the issue.  Note how the cursor doesn't change back to default when hovering outside of the small square.

Fix so that when the cursor is updated, the incoming is checked for truthiness.  If it is, use it, else keep it as an empty string.