### PR TITLE
Fixes issue with bitmap cache and bounds calculations

### DIFF
--- a/extras/SVGExporter/SVGExporter.js
+++ b/extras/SVGExporter/SVGExporter.js
@@ -291,7 +291,8 @@
 		var img = this._getImage(o.cacheCanvas, "cache");
 		if (!img) { return; }
 		// don't forget cache offset & scale
-		return this.exportCommon(img, o, "cache", o._cacheOffsetX, o._cacheOffsetY, o._cacheScale);
+		var cache = o.bitmapCache;
+		return this.exportCommon(img, o, "cache", cache._filterOffX, cache._filterOffY, cache.scale);
 	};
 
 	p.exportContainer = function(o) {

--- a/src/easeljs/display/DisplayObject.js
+++ b/src/easeljs/display/DisplayObject.js
@@ -719,7 +719,7 @@ this.createjs = this.createjs||{};
 			},
 			scale: {
 				get: function() { return this.scaleX; },
-				set: function(scale) { this.scaleX = this.scaleY = scale; },
+				set: function(scale) { this.scaleX = this.scaleY = scale; }
 			}
 		});
 	} catch (e) {}

--- a/src/easeljs/display/DisplayObject.js
+++ b/src/easeljs/display/DisplayObject.js
@@ -1144,10 +1144,9 @@ this.createjs = this.createjs||{};
 	 **/
 	p.getBounds = function() {
 		if (this._bounds) { return this._rectangle.copy(this._bounds); }
-		var cacheCanvas = this.cacheCanvas;
-		if (cacheCanvas) {
-			var scale = this._cacheScale;
-			return this._rectangle.setValues(this._cacheOffsetX, this._cacheOffsetY, cacheCanvas.width/scale, cacheCanvas.height/scale);
+		var cache = this.bitmapCache;
+		if (cache) {
+			return cache.getBounds();
 		}
 		return null;
 	};

--- a/src/easeljs/display/StageGL.js
+++ b/src/easeljs/display/StageGL.js
@@ -1479,7 +1479,7 @@ this.createjs = this.createjs||{};
 		var texture = this.getBaseTexture(w, h);
 
 		if(!texture) {
-			msg = "Problem creating texture, possible cause: using too much VRAM, please try releasing texture memory";
+			var msg = "Problem creating texture, possible cause: using too much VRAM, please try releasing texture memory";
 			(console.error && console.error(msg)) || console.log(msg);
 
 			texture = this._baseTextures[0];
@@ -1644,7 +1644,7 @@ this.createjs = this.createjs||{};
 	 */
 	p._createShader = function (gl, type, str) {
 		// inject the static number
-		str = str.replace(/{{count}}/g, this._batchTextureCount);
+		str = str.replace(/\{\{count}}/g, this._batchTextureCount);
 
 		// resolve issue with no dynamic samplers by creating correct samplers in if else chain
 		// TODO: WebGL 2.0 does not need this support
@@ -1652,8 +1652,8 @@ this.createjs = this.createjs||{};
 		for (var i = 1; i<this._batchTextureCount; i++) {
 			insert += "} else if (indexPicker <= "+ i +".5) { color = texture2D(uSampler["+ i +"], vTextureCoord);";
 		}
-		str = str.replace(/{{alternates}}/g, insert);
-		str = str.replace(/{{fragColor}}/g, this._premultiply ? StageGL.REGULAR_FRAG_COLOR_PREMULTIPLY : StageGL.REGULAR_FRAG_COLOR_NORMAL);
+		str = str.replace(/\{\{alternates}}/g, insert);
+		str = str.replace(/\{\{fragColor}}/g, this._premultiply ? StageGL.REGULAR_FRAG_COLOR_PREMULTIPLY : StageGL.REGULAR_FRAG_COLOR_NORMAL);
 
 		// actually compile the shader
 		var shader = gl.createShader(type);

--- a/src/easeljs/filters/BitmapCache.js
+++ b/src/easeljs/filters/BitmapCache.js
@@ -193,6 +193,15 @@ this.createjs = this.createjs||{};
 		 * @default 0
 		 **/
 		this._drawHeight = 0;
+
+		/**
+		 * Internal tracking of the last requested bounds, may happen repeadtedly so stored to avoid object creation
+		 * @property _boundRect
+		 * @protected
+		 * @type {Rectangle}
+		 * @default 0
+		 **/
+		this._boundRect = new createjs.Rectangle();
 	}
 	var p = BitmapCache.prototype;
 
@@ -399,6 +408,19 @@ this.createjs = this.createjs||{};
 			this._drawWidth/this.scale,					this._drawHeight/this.scale
 		);
 		return true;
+	};
+
+	/**
+	 * Determine the bounds of the shape in local space.
+	 * @method getBounds
+	 * @returns {Rectangle}
+	 */
+	p.getBounds = function() {
+		var scale = this.scale;
+		return this._boundRect.setValue(
+			this._filterOffX/scale,		this._filterOffY/scale,
+			this.width/scale,			this.height/scale
+		);
 	};
 
 // private methods:

--- a/src/easeljs/filters/BitmapCache.js
+++ b/src/easeljs/filters/BitmapCache.js
@@ -410,8 +410,10 @@ this.createjs = this.createjs||{};
 	 * @protected
 	 **/
 	p._updateSurface = function() {
+		var surface;
+
 		if (!this._options || !this._options.useGL) {
-			var surface = this.target.cacheCanvas;
+			surface = this.target.cacheCanvas;
 
 			// create it if it's missing
 			if(!surface) {
@@ -451,7 +453,7 @@ this.createjs = this.createjs||{};
 		}
 
 		// now size render surfaces
-		var surface = this.target.cacheCanvas;
+		surface = this.target.cacheCanvas;
 		var stageGL = this._webGLCache;
 
 		// if we have a dedicated stage we've gotta size it
@@ -483,7 +485,6 @@ this.createjs = this.createjs||{};
 		var webGL = this._webGLCache;
 
 		if (webGL){
-			//TODO: auto split blur into an x/y pass
 			webGL.cacheDraw(target, target.filters, this);
 
 			// we may of swapped around which element the surface is, so we re-fetch it


### PR DESCRIPTION
Minor code cleanup, with a fix to resolve some old code pointing to cache properties that have been removed. Should of been caught during deprecation, but was apparently missed.