### PR TITLE
Prevent error on Touch.disable(stage)

### DIFF
--- a/src/easeljs/ui/Touch.js
+++ b/src/easeljs/ui/Touch.js
@@ -110,7 +110,7 @@ this.createjs = this.createjs||{};
 	 * @static
 	 **/
 	Touch.disable = function(stage) {
-		if (!stage) { return; }
+		if (!stage||!stage.__touch) { return; }
 		if ('ontouchstart' in window) { Touch._IOS_disable(stage); }
 		else if (window.PointerEvent || window.MSPointerEvent) { Touch._IE_disable(stage); }
 		


### PR DESCRIPTION
If the browser doesn't support touch events, then calling Touch.disable causes an error.  The error is because stage.__touch is never initiated in Touch.enable and so trying to delete it causes an error.  This is fixed by adding a check for stage.__touch in Touch.disable.