### PR TITLE
added mediump precission fallback in shaders

### DIFF
--- a/src/easeljs/display/StageGL.js
+++ b/src/easeljs/display/StageGL.js
@@ -752,7 +752,11 @@ this.createjs = this.createjs||{};
 	 * @readonly
 	 */
 	StageGL.REGULAR_VARYING_HEADER = (
-		"precision highp float;" +
+		"#ifdef GL_FRAGMENT_PRECISION_HIGH \n"+
+		"precision highp float; \n"+
+		"#else \n"+
+		"precision mediump float; \n"+
+		"#endif \n"+
 
 		"varying vec2 vTextureCoord;" +
 		"varying lowp float indexPicker;" +
@@ -847,7 +851,11 @@ this.createjs = this.createjs||{};
 	 * @readonly
 	 */
 	StageGL.COVER_VARYING_HEADER = (
-		"precision highp float;" +	//this is usually essential for filter math
+		"#ifdef GL_FRAGMENT_PRECISION_HIGH \n"+
+		"precision highp float; \n"+
+		"#else \n"+
+		"precision mediump float; \n"+
+		"#endif \n"+
 
 		"varying vec2 vTextureCoord;"
 	);


### PR DESCRIPTION
Hello, this is a small fix that implemented for the stageGL shaders. It allows to run the webGL render system in low-end mobile GPUs like the ARM mali-400 (https://developer.arm.com/ip-products/graphics-and-multimedia/mali-gpus/mali-400-gpu)
